### PR TITLE
Fix OSX El Capitan CUDA incompatibility, by adding lib to rpath

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,8 @@ ifeq ($(UNAME), Linux)
 	LINUX := 1
 else ifeq ($(UNAME), Darwin)
 	OSX := 1
+	OSX_MAJOR_VERSION := $(shell sw_vers -productVersion | cut -f 1 -d .)
+	OSX_MINOR_VERSION := $(shell sw_vers -productVersion | cut -f 2 -d .)
 endif
 
 # Linux
@@ -249,6 +251,14 @@ ifeq ($(OSX), 1)
 		endif
 		# clang throws this warning for cuda headers
 		WARNINGS += -Wno-unneeded-internal-declaration
+		# 10.11 strips DYLD_* env vars so link CUDA (rpath is available on 10.5+)
+		OSX_10_OR_LATER   := $(shell [ $(OSX_MAJOR_VERSION) -ge 10 ] && echo true)
+		OSX_10_5_OR_LATER := $(shell [ $(OSX_MINOR_VERSION) -ge 5 ] && echo true)
+		ifeq ($(OSX_10_OR_LATER),true)
+			ifeq ($(OSX_10_5_OR_LATER),true)
+				LDFLAGS += -Wl,-rpath,$(CUDA_LIB_DIR)
+			endif
+		endif
 	endif
 	# gtest needs to use its own tuple to not conflict with clang
 	COMMON_FLAGS += -DGTEST_USE_OWN_TR1_TUPLE=1


### PR DESCRIPTION
(cherry picked from commit dac4d0962dffb11f9fb670e70126aebe31ddae5a)

See: BVLC/caffe#3227

Without this, I get the following error when I try to `make runtest`:

```
dyld: Library not loaded: @rpath/libcudart.7.5.dylib
  Referenced from: /Users/ryan/source/caffe-segnet/.build_release/tools/caffe
  Reason: image not found
make: *** [runtest] Trace/BPT trap: 5
```
